### PR TITLE
chore: ♻ update docker installation process to use keyrings and architecture mapping

### DIFF
--- a/ansible/infra/roles/common/docker/tasks/main.yml
+++ b/ansible/infra/roles/common/docker/tasks/main.yml
@@ -9,16 +9,42 @@
     - gnupg
     - lsb-release
 
-- name: Add Docker GPG apt Key
-  ansible.builtin.apt_key:
+- name: Ensure keyrings directory exists
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Download Docker GPG key (as .asc)
+  ansible.builtin.get_url:
     url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
-    state: present
+    dest: /etc/apt/keyrings/docker.asc
+    mode: '0644'
+    force: true
 
-- name: Add Docker Repository
+- name: Map architectures
+  ansible.builtin.set_fact:
+    docker_arch_map:
+      x86_64: amd64
+      armv7l: armhf
+      armhf: armhf
+      aarch64: arm64
+      arm64: arm64
+
+- name: Set docker_arch
+  ansible.builtin.set_fact:
+    docker_arch: "{{ docker_arch_map.get(ansible_architecture, ansible_architecture) }}"
+
+- name: Add Docker repository
   ansible.builtin.apt_repository:
-    repo: deb https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }} stable
+    repo: "deb [arch={{ docker_arch }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+    filename: docker
     state: present
 
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: true
+    
 - name: Install Docker
   ansible.builtin.apt:
     name: "{{ item }}"


### PR DESCRIPTION
Clean up your APT list; otherwise, two different methods will be used and APT will crash when updating.

## Description

Following the official Docker documentation, the new standard is the apt keyring.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Tested at home on my personal homelab.
Need to be tested on Raspberry Pi 4 (I tried to pre-shoot Ansible architecture facts, but I could be wrong).

## How to cleanup apt before apply this

```bash
sudo rm -f /etc/apt/sources.list.d/docker.list
sudo rm -f /etc/apt/sources.list.d/download_docker_com_linux_debian.list

sudo rm -f /etc/apt/keyrings/docker.* 

sudo sed -i '/download.docker.com\/linux\/debian/d' /etc/apt/sources.list

sudo rm -rf /var/lib/apt/lists/*
sudo apt-get clean
```
